### PR TITLE
Fix NsSpyglass README links automatically

### DIFF
--- a/_includes/readmes/NsSpyglass.md
+++ b/_includes/readmes/NsSpyglass.md
@@ -2,9 +2,9 @@
 NsSpyglass is a small yet powerful plugin dependency viewer for Unreal Engine.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/main/Resources/ShowcaseGraphOut.gif" width="250" /> &nbsp;
-  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/main/Resources/ShowcaseGraphIn.gif" width="250" /> &nbsp;
-  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/main/Resources/ShowcaseGraphMove.gif" width="250" />
+  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/refs/heads/main/Resources/ShowcaseGraphOut.gif" width="250" /> &nbsp;
+  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/refs/heads/main/Resources/ShowcaseGraphIn.gif" width="250" /> &nbsp;
+  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/refs/heads/main/Resources/ShowcaseGraphMove.gif" width="250" />
 </div>
 
 ## 📦 Features

--- a/_includes/readmes/NsSpyglass.md
+++ b/_includes/readmes/NsSpyglass.md
@@ -2,9 +2,9 @@
 NsSpyglass is a small yet powerful plugin dependency viewer for Unreal Engine.
 
 <div align="center">
-  <img src="https://github.com/mykaadev/NsSpyglass/blob/main/Resources/ShowcaseGraphOut.gif" width="250" /> &nbsp;
-  <img src="https://github.com/mykaadev/NsSpyglass/blob/main/Resources/ShowcaseGraphIn.gif" width="250" /> &nbsp;
-  <img src="https://github.com/mykaadev/NsSpyglass/blob/main/Resources/ShowcaseGraphMove.gif" width="250" />
+  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/main/Resources/ShowcaseGraphOut.gif" width="250" /> &nbsp;
+  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/main/Resources/ShowcaseGraphIn.gif" width="250" /> &nbsp;
+  <img src="https://raw.githubusercontent.com/mykaadev/NsSpyglass/main/Resources/ShowcaseGraphMove.gif" width="250" />
 </div>
 
 ## 📦 Features

--- a/_includes/readmes/NsSpyglass.md
+++ b/_includes/readmes/NsSpyglass.md
@@ -20,7 +20,7 @@ Unreal Engine 5.2+
 3. Generate project files and enable the plugin when prompted.
 
 ## 🚀 Getting Started
-Open your Unreal Engine editor and head up to `Window` > `Spyglass` > `Plugin Dependency Viewer` and start exploreing all your loaded plugins and their references.
+Open your Unreal Engine editor and head up to `Window` > `Spyglass` > `Plugin Dependency Viewer` and start exploring all your loaded plugins and their dependencies.
 
 
 

--- a/_plugins/fetch_readmes.rb
+++ b/_plugins/fetch_readmes.rb
@@ -32,6 +32,24 @@ module Jekyll
       content.gsub(/<!--\s*PLUGIN_META.*?PLUGIN_META\s*-->/m, "")
     end
 
+    def fix_relative_asset_links(content, repo, branch)
+      base = "https://raw.githubusercontent.com/mykaadev/#{repo}/#{branch}/"
+
+      # Replace Markdown image paths
+      content = content.gsub(/!\[([^\]]*)\]\((?!https?:\/\/)([^)]+)\)/) do
+        alt = Regexp.last_match(1)
+        path = Regexp.last_match(2).sub(%r{^\.?/}, "")
+        "![#{alt}](#{base}#{path})"
+      end
+
+      # Replace HTML <img> src attributes
+      content.gsub(/<img([^>]*?)src=\"(?!https?:\/\/)([^\">]+)\"/) do
+        attrs = Regexp.last_match(1)
+        path  = Regexp.last_match(2).sub(%r{^\.?/}, "")
+        "<img#{attrs}src=\"#{base}#{path}\""
+      end
+    end
+
     def generate(site)
       dest_dir = File.join(site.source, "_includes", "readmes")
       FileUtils.mkdir_p(dest_dir)
@@ -50,6 +68,7 @@ module Jekyll
           content = response.body.force_encoding("UTF-8")
           content = remove_gh_only_sections(content)
           content = remove_meta_blocks(content)
+          content = fix_relative_asset_links(content, repo, branch)
           content << "\n\n---\n\n> [⬇ Download on GitHub](https://github.com/mykaadev/#{repo})"
 
           File.write(File.join(dest_dir, "#{repo}.md"), content.strip)


### PR DESCRIPTION
## Summary
- update the fetch_readmes generator to convert relative asset paths
  to raw GitHub URLs
